### PR TITLE
Update login error message text.

### DIFF
--- a/backend/src/main/resources/templates/login.html
+++ b/backend/src/main/resources/templates/login.html
@@ -39,7 +39,7 @@
         <div class="card mdc-elevation--z8">
 
             <div th:if="${error}" class="text text--roboto alert alert-error">
-                Invalid cid/email and password.
+                Invalid cid/email or password.
                 <div class="padding"></div>
             </div>
             <div th:if="${logout}" class="text text--roboto alert alert-success">


### PR DESCRIPTION
Currently it says "invalid cid/email and password", however since not necesarily both are wrong 'or' might be more appropriate.