### PR TITLE
Expand Docker image tagging

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Build Docker image
         run: ./gradlew bootBuildImage
 
-      - name: Create manifest list and push
+      - name: Push docker image
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            app:latest    
+          for tag in $(jq -r '.tags | join(" ")' <<< "${{ steps.meta.outputs.metadata }}"); do
+            docker image tag app:latest $tag
+          done
+          docker image push --all-tags ghcr.io/${{ github.repository_owner }}/gamma  

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -1,8 +1,12 @@
 name: Build Docker Image
+
 on:
   push:
+    branches: [main]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -31,11 +35,25 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/gamma
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr  
+
       - name: Build Docker image
         run: ./gradlew bootBuildImage
 
-      - name: Docker Tag and Build
-        run: |
-          version=${GITHUB_REF#refs/tags/}
-          docker tag app:latest ghcr.io/${{ github.repository_owner }}/gamma:${version}
-          docker push ghcr.io/${{ github.repository_owner }}/gamma:${version}
+      - name: Push image
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: app:latest
+          dst: |
+            ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Build Docker image
         run: ./gradlew bootBuildImage
 
-      - name: Push image
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: app:latest
-          dst: |
-            ${{ steps.meta.outputs.tags }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            app:latest    

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Push docker image
         run: |
-          for tag in $(jq -r '.tags | join(" ")' <<< "${{ steps.meta.outputs.metadata }}"); do
+          for tag in $(jq -r '.tags | join(" ")' <<< $DOCKER_METADATA_OUTPUT_JSON ); do
             docker image tag app:latest $tag
           done
           docker image push --all-tags ghcr.io/${{ github.repository_owner }}/gamma  

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -52,7 +52,6 @@ jobs:
         run: ./gradlew bootBuildImage
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             app:latest    

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -45,7 +45,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            type=ref,event=branch
+            type=edge
             type=ref,event=pr  
 
       - name: Build Docker image


### PR DESCRIPTION
This PR expands the Docker image tags to be more extensive.

As written this workflow will create the following tags in the following scenarios.

On push/merge to main:

- ~:main~ :edge
- :sha-xxxxxxx where xxxxxxx is the start of the git commit hash

On PR targeting main:

- :pr-xx-head where xx is the PR number
- :sha-xxxxxxx where xxxxxxx is the start of the git commit hash

On Git tag:

- :sha-xxxxxxx where xxxxxxx is the start of the git commit hash
- :x where x is the major version
- :x.y where x is the major version and y the minor
- :x.y.z :x.y where x is the major, y the minor and z is the patch version
- :latest


Before I mark this draft PR as ready to merge I would like some feedback on which of these tags we actually want. For now I have basically included everything but I don't know if we only want some subset of these or if we like this extensive system?
