### PR TITLE
Fix short session times

### DIFF
--- a/app/src/main/java/it/chalmers/gamma/security/SessionConfig.java
+++ b/app/src/main/java/it/chalmers/gamma/security/SessionConfig.java
@@ -5,10 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration
-@EnableRedisHttpSession
 public class SessionConfig {
 
   @Value("${spring.data.redis.host}")


### PR DESCRIPTION
Currently the session timeout for Gamma is 30 min which does not respect what is in the config/ENV.
The cause of this was that EnableRedisHttpSession was called in the code instead of letting spring boot set it up from the config. This caused the spring.session.timeout (and anything under spring.session.*) setting to be ignored. By removing EnableRedisHttpSession we let spring configure it based on spring.session.store-type.

