### PR TITLE
Flip erroneous return in hasAccessToUser

### DIFF
--- a/app/src/main/java/it/chalmers/gamma/app/authentication/UserAccessGuard.java
+++ b/app/src/main/java/it/chalmers/gamma/app/authentication/UserAccessGuard.java
@@ -103,7 +103,7 @@ public class UserAccessGuard {
     LOGGER.debug("tried to access the user: {}; ", userId);
 
     // Return false by default
-    return true;
+    return false;
   }
 
   private boolean isInternalAuthenticated() {


### PR DESCRIPTION
Unfortunately, what seems like a quick "set it to true to check something" has slipped into the main branch.

However, I'm fairly certain that this doesn't mean unallowed access has happened, since all facade methods always calls AccessGuard in one way or another. But that can be investigated further after this has been merged, and deployed to production. 